### PR TITLE
respect .nomedia .noimage

### DIFF
--- a/lib/Service/ImagesFinderService.php
+++ b/lib/Service/ImagesFinderService.php
@@ -44,6 +44,10 @@ class ImagesFinderService
      */
     public function findImagesInFolder(Folder $folder, &$results = []):array {
         $this->logger->debug('Searching '.$folder->getInternalPath());
+        if ($folder->nodeExists('.noimage') || $folder->nodeExists('.nomedia')) {
+            $this->logger->debug('Passing '.$folder->getInternalPath());
+            return $results;
+        }
         $nodes = $folder->getDirectoryListing();
         foreach ($nodes as $node) {
             if ($node instanceof Folder) {


### PR DESCRIPTION
Do not scan files in folders (and their subfolders) containing a `.nomedia` or `.noimage` file