### PR TITLE
purejs fix config checkbox initial values

### DIFF
--- a/lib/Service/ClassifyImagenetService.php
+++ b/lib/Service/ClassifyImagenetService.php
@@ -64,10 +64,10 @@ class ClassifyImagenetService {
 
         $this->logger->debug('Running '.var_export($command, true));
         $proc = new Process($command, __DIR__);
-        if ($this->config->getAppValue('recognize', 'tensorflow.gpu', 'false') !== 'false') {
+        if ($this->config->getAppValue('recognize', 'tensorflow.gpu', 'false') === 'true') {
             $proc->setEnv(['RECOGNIZE_GPU' => 'true']);
         }
-        if ($this->config->getAppValue('recognize', 'tensorflow.purejs', 'false') !== 'false') {
+        if ($this->config->getAppValue('recognize', 'tensorflow.purejs', 'false') === 'true') {
             $proc->setEnv(['RECOGNIZE_PUREJS' => 'true']);
             $proc->setTimeout(count($paths) * self::IMAGE_PUREJS_TIMEOUT);
         }else{


### PR DESCRIPTION
For some reason initial value wasn't set at first, `$this->config->getAppValue('recognize', 'tensorflow.purejs', 'false')` had the value `''`