### PR TITLE
Ignore non-owner images

### DIFF
--- a/lib/Service/AudioFinderService.php
+++ b/lib/Service/AudioFinderService.php
@@ -25,7 +25,7 @@ class AudioFinderService extends FileFinderService {
 	/**
 	 * @throws NotFoundException|InvalidPathException
 	 */
-	public function findAudioInFolder(Folder $folder):array {
-		return $this->findFilesInFolder($folder);
+	public function findAudioInFolder(string $user, Folder $folder):array {
+		return $this->findFilesInFolder($user, $folder);
 	}
 }

--- a/lib/Service/ClassifyAudioService.php
+++ b/lib/Service/ClassifyAudioService.php
@@ -54,7 +54,7 @@ class ClassifyAudioService {
 			return false;
 		}
 		$this->logger->debug('Collecting audio files of user '.$user);
-		$files = $this->audioFinder->findAudioInFolder($this->rootFolder->getUserFolder($user));
+		$files = $this->audioFinder->findAudioInFolder($user, $this->rootFolder->getUserFolder($user));
 		if (count($files) === 0) {
 			$this->logger->debug('No audio files found of user '.$user);
 			return false;

--- a/lib/Service/ClassifyImagesService.php
+++ b/lib/Service/ClassifyImagesService.php
@@ -72,7 +72,7 @@ class ClassifyImagesService {
 			return false;
 		}
 		$this->logger->debug('Collecting photos of user '.$user);
-		$images = $this->imagesFinder->findImagesInFolder($this->rootFolder->getUserFolder($user));
+		$images = $this->imagesFinder->findImagesInFolder($user, $this->rootFolder->getUserFolder($user));
 		if (count($images) === 0) {
 			$this->logger->debug('No unclassified photos found by user '.$user);
 			return false;

--- a/lib/Service/FileFinderService.php
+++ b/lib/Service/FileFinderService.php
@@ -80,7 +80,7 @@ class FileFinderService {
 	/**
 	 * @throws NotFoundException|InvalidPathException
 	 */
-	public function findFilesInFolder(Folder $folder, &$results = []):array {
+	public function findFilesInFolder(string $user, Folder $folder, &$results = []):array {
 		$this->logger->debug('Searching '.$folder->getInternalPath());
 
 		$foundMarkers = array_filter($this->ignoreMarkers, static function ($markerFile) use ($folder) {
@@ -95,11 +95,14 @@ class FileFinderService {
 		$nodes = $folder->getDirectoryListing();
 		foreach ($nodes as $node) {
 			if ($node instanceof Folder) {
-				$this->findFilesInFolder($node, $results);
+				$this->findFilesInFolder($user, $node, $results);
 			} elseif ($node instanceof File) {
 				if ($this->objectMapper->haveTag([$node->getId()], 'files', $this->recognizedTag->getId())) {
 					continue;
 				}
+                if ($node->getOwner()->getUID() !== $user) {
+                    continue;
+                }
 				$mimeType = $node->getMimetype();
 				if (!in_array($mimeType, $this->formats)) {
 					continue;

--- a/lib/Service/ImagesFinderService.php
+++ b/lib/Service/ImagesFinderService.php
@@ -27,7 +27,7 @@ class ImagesFinderService extends FileFinderService {
 	/**
 	 * @throws NotFoundException|InvalidPathException
 	 */
-	public function findImagesInFolder(Folder $folder):array {
-		return $this->findFilesInFolder($folder);
+	public function findImagesInFolder(string $user, Folder $folder):array {
+		return $this->findFilesInFolder($user, $folder);
 	}
 }


### PR DESCRIPTION
Scenario: Bob shares an image with Alice. The image will be classified under user Alice (since a comes before b in the alphabet) and recognize will use Alice's contacts for face recognition.

Desired behavior: Bob owns the photo so his contacts should be used for face recognition.

This solution will ignore photos in the scanning process which are not owned by the current user.