### PR TITLE
Use proper event class with the new dispatcher

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -14,6 +14,7 @@ use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\Events\Node\NodeDeletedEvent;
 
 class Application extends App implements IBootstrap {
 	public const APP_ID = 'recognize';
@@ -24,7 +25,7 @@ class Application extends App implements IBootstrap {
 		 * @var IEventDispatcher $dispatcher
 		 */
 		$dispatcher = $this->getContainer()->get(IEventDispatcher::class);
-		$dispatcher->addServiceListener('\OCP\Files::postDelete', FileListener::class);
+		$dispatcher->addServiceListener(NodeDeletedEvent::class, FileListener::class);
 	}
 
 	public function register(IRegistrationContext $context): void {


### PR DESCRIPTION
Make sure to use the proper new Event class instead of the older named Symfony event.

Avoids the following error, found when running occ maintenance:repair during having recognize enabled:

```
{
  "reqId": "NEttqVqVhQmJ7ZARFc6O",
  "level": 3,
  "time": "2022-07-15T14:40:05+00:00",
  "remoteAddr": "",
  "user": "--",
  "app": "cron",
  "method": "",
  "url": "--",
  "message": "OC\\EventDispatcher\\ServiceEventListener::__invoke(): Argument #1 ($event) must be of type OCP\\EventDispatcher\\Event, OC\\EventDispatcher\\GenericEventWrapper given, called in /var/www/html/3rdparty/symfony/event-dispatcher/EventDispatcher.php on line 251",
  "userAgent": "--",
  "version": "25.0.0.4",
  "exception": {
    "Exception": "TypeError",
    "Message": "OC\\EventDispatcher\\ServiceEventListener::__invoke(): Argument #1 ($event) must be of type OCP\\EventDispatcher\\Event, OC\\EventDispatcher\\GenericEventWrapper given, called in /var/www/html/3rdparty/symfony/event-dispatcher/EventDispatcher.php on line 251",
    "Code": 0,
    "Trace": [
      {
        "file": "/var/www/html/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
        "line": 251,
        "function": "__invoke",
        "class": "OC\\EventDispatcher\\ServiceEventListener",
        "type": "->",
        "args": [
          {
            "__class__": "OC\\EventDispatcher\\GenericEventWrapper"
          },
          "\\OCP\\Files::postDelete",
          {
            "__class__": "Symfony\\Component\\EventDispatcher\\EventDispatcher"
          }
        ]
      },
      {
        "file": "/var/www/html/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
        "line": 73,
        "function": "callListeners",
        "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          [
            {
              "__class__": "Closure"
            }
          ],
          "\\OCP\\Files::postDelete",
          {
            "__class__": "OC\\EventDispatcher\\GenericEventWrapper"
          }
        ]
      },
      {
        "file": "/var/www/html/lib/private/EventDispatcher/SymfonyAdapter.php",
        "line": 122,
        "function": "dispatch",
        "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OC\\EventDispatcher\\GenericEventWrapper"
          },
          "\\OCP\\Files::postDelete"
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/Node/Node.php",
        "line": 118,
        "function": "dispatch",
        "class": "OC\\EventDispatcher\\SymfonyAdapter",
        "type": "->",
        "args": [
          "\\OCP\\Files::postDelete",
          {
            "__class__": "Symfony\\Component\\EventDispatcher\\GenericEvent"
          }
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/Node/File.php",
        "line": 133,
        "function": "sendHooks",
        "class": "OC\\Files\\Node\\Node",
        "type": "->",
        "args": [
          [
            "postDelete"
          ],
          [
            {
              "__class__": "OC\\Files\\Node\\NonExistingFile"
            }
          ]
        ]
      },
      {
        "file": "/var/www/html/lib/private/Files/SimpleFS/SimpleFile.php",
        "line": 149,
        "function": "delete",
        "class": "OC\\Files\\Node\\File",
        "type": "->",
        "args": []
      },
      {
        "file": "/var/www/html/apps/text/lib/Service/DocumentService.php",
        "line": 350,
        "function": "delete",
        "class": "OC\\Files\\SimpleFS\\SimpleFile",
        "type": "->",
        "args": []
      },
      {
        "file": "/var/www/html/apps/text/lib/Cron/Cleanup.php",
        "line": 79,
        "function": "resetDocument",
        "class": "OCA\\Text\\Service\\DocumentService",
        "type": "->",
        "args": [
          1824
        ]
      },
      {
        "file": "/var/www/html/lib/public/BackgroundJob/Job.php",
        "line": 79,
        "function": "run",
        "class": "OCA\\Text\\Cron\\Cleanup",
        "type": "->",
        "args": [
          null
        ]
      },
      {
        "file": "/var/www/html/lib/public/BackgroundJob/TimedJob.php",
        "line": 95,
        "function": "execute",
        "class": "OCP\\BackgroundJob\\Job",
        "type": "->",
        "args": [
          {
            "__class__": "OC\\BackgroundJob\\JobList"
          },
          {
            "__class__": "OC\\Log"
          }
        ]
      },
      {
        "file": "/var/www/html/cron.php",
        "line": 152,
        "function": "execute",
        "class": "OCP\\BackgroundJob\\TimedJob",
        "type": "->",
        "args": [
          {
            "__class__": "OC\\BackgroundJob\\JobList"
          },
          {
            "__class__": "OC\\Log"
          }
        ]
      }
    ],
    "File": "/var/www/html/lib/private/EventDispatcher/ServiceEventListener.php",
    "Line": 65,
    "CustomMessage": "--"
  }
}
```
